### PR TITLE
build: upgrade dependencies to '3.0.1' and platform to 'iOS 15'

### DIFF
--- a/Package.resolved
+++ b/Package.resolved
@@ -14,8 +14,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/BatchLabs/Batch-iOS-SDK",
       "state" : {
-        "revision" : "72ab052438d8eae2eb822d0442ea9c1c2e9f9701",
-        "version" : "2.0.2"
+        "revision" : "4c6c2b321d65eebd2df6f048395b2f3168ec24b2",
+        "version" : "3.0.1"
       }
     },
     {

--- a/Package.swift
+++ b/Package.swift
@@ -5,6 +5,7 @@ import PackageDescription
 let package = Package(
     name: "BatchFirebaseDispatcher",
     defaultLocalization: "en",
+    platforms: [.iOS(.v15)],
     products: [
         // Products define the executables and libraries a package produces, and make them visible to other packages.
         .library(
@@ -13,7 +14,7 @@ let package = Package(
     ],
     dependencies: [
         // Dependencies declare other packages that this package depends on.
-        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK","1.19.0"..."99.0.0"),
+        .package(url: "https://github.com/BatchLabs/Batch-iOS-SDK","3.0.1"..."99.0.0"),
         .package(url: "https://github.com/firebase/firebase-ios-sdk", "8.10.0"..."99.0.0"),
     ],
     targets: [
@@ -22,6 +23,7 @@ let package = Package(
         .target(
             name: "BatchFirebaseDispatcher",
             dependencies: [
+                .product(name: "Batch", package: "Batch-iOS-SDK"),
                 .product(name: "FirebaseAnalytics", package: "firebase-ios-sdk"),
             ],
             path: "BatchFirebaseDispatcher",


### PR DESCRIPTION
following latest 3.0.1 tag for Batch-ios-sdk which introduced .iOS(.v15) platforms requirement.

the dispatcher framework also needs update to specify that platform requirement.

> https://github.com/BatchLabs/Batch-iOS-piano-dispatcher/pull/3